### PR TITLE
feat: add PR build test workflow

### DIFF
--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -1,0 +1,36 @@
+name: PR Build Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE_NAME: ccimen/eneo-testcicd-backend
+  FRONTEND_IMAGE_NAME: ccimen/eneo-testcicd-frontend
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    name: Test Docker builds
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Test build backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: false
+          tags: test-build
+      
+      - name: Test build frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: false
+          tags: test-build


### PR DESCRIPTION
## Summary
Add Docker build testing to PRs to catch build failures early.

## Changes
- ✅ **New workflow**: 
- ✅ **Tests both**: backend and frontend Docker builds
- ✅ **PR-only**: No images pushed, just build verification
- ✅ **Updated naming**: Uses `ccimen/eneo-testcicd` image names
- ✅ **Parallel execution**: Runs alongside linting checks

## Benefits
- 🛡️ **Prevents broken builds** from reaching main/develop
- ⚡ **Fast feedback** - catches Docker issues immediately
- 🔄 **CI/CD safety** - ensures deployments will work
- 🧪 **Test-friendly** - verifies both environments

This complements our hybrid linting approach with build verification!